### PR TITLE
Add clean-state noop acceptance test

### DIFF
--- a/spec/acceptance/suites/default/ff_spec.rb
+++ b/spec/acceptance/suites/default/ff_spec.rb
@@ -9,6 +9,22 @@ describe 'mozilla::firefox' do
     EOS
   end
 
+  # Exercise noop from a clean (uninstalled) state: on a fresh node the Sicura
+  # console previews the module with `puppet apply --noop`, which must not error
+  # even though nothing mozilla manages exists yet. Real idempotence is covered
+  # by the applies below. A post-convergence noop check is deliberately omitted:
+  # `puppet apply --noop --detailed-exitcodes` always exits 0, so it could never
+  # fail and would test nothing.
+  context 'in noop mode from a clean state' do
+    before(:context) do
+      on(hosts, 'puppet resource package firefox ensure=absent')
+    end
+
+    it 'applies without errors in noop mode' do
+      apply_manifest(manifest, catch_failures: true, noop: true)
+    end
+  end
+
   context 'with defaults' do
     it 'works with no errors' do
       apply_manifest(manifest, catch_failures: true)

--- a/spec/acceptance/suites/default/tb_spec.rb
+++ b/spec/acceptance/suites/default/tb_spec.rb
@@ -9,6 +9,22 @@ describe 'mozilla::thunderbird' do
     EOS
   end
 
+  # Exercise noop from a clean (uninstalled) state: on a fresh node the Sicura
+  # console previews the module with `puppet apply --noop`, which must not error
+  # even though nothing mozilla manages exists yet. Real idempotence is covered
+  # by the applies below. A post-convergence noop check is deliberately omitted:
+  # `puppet apply --noop --detailed-exitcodes` always exits 0, so it could never
+  # fail and would test nothing.
+  context 'in noop mode from a clean state' do
+    before(:context) do
+      on(hosts, 'puppet resource package thunderbird ensure=absent')
+    end
+
+    it 'applies without errors in noop mode' do
+      apply_manifest(manifest, catch_failures: true, noop: true)
+    end
+  end
+
   context 'with defaults' do
     it 'works with no errors' do
       apply_manifest(manifest, catch_failures: true)


### PR DESCRIPTION
Adds an acceptance example that applies the module under `puppet apply --noop` from a fresh, uninstalled node — mirroring the preview the Sicura console runs on a clean host — and asserts it completes without error. It reuses the suite's existing default manifest so the check stays representative of the module's real default, and deliberately omits a post-convergence noop check (`--noop --detailed-exitcodes` always exits 0, so it would test nothing).